### PR TITLE
Fix Flaky Test

### DIFF
--- a/tests/test_prepareDeploymentServiceDefinitionStep.py
+++ b/tests/test_prepareDeploymentServiceDefinitionStep.py
@@ -317,6 +317,7 @@ def test_process_application_autoscaling_scalable_target_min_capacity_valid():
     assert target['MinCapacity'] == source['min_capacity']  
 
 def test_process_application_autoscaling_scalable_target_max_capacity_invalid():
+    step.infos.scale_infos = ScaleInfos()
     source = {}
     source['max_capacity'] = 'a'
     target = {}


### PR DESCRIPTION
<h2>What is the purpose of this PR</h2>

- This PR patches `tests/test_prepareDeploymentServiceDefinitionStep.py::test_process_application_autoscaling_scalable_target_max_capacity_invalid` and prevents it from failing when it is run by itself
- Test is flaky (non-deterministic) and depends on `tests/test_prepareDeploymentServiceDefinitionStep.py::test_process_application_autoscaling_scalable_target_min_capacity_valid` to set up a state to pass, but the test fails when it is run by itself otherwise

---

<h2>Expected Result</h2> 

- Test `tests/test_prepareDeploymentServiceDefinitionStep.py::test_process_application_autoscaling_scalable_target_max_capacity_invalid` should pass when run both by itself and after `tests/test_prepareDeploymentServiceDefinitionStep.py::test_process_application_autoscaling_scalable_target_min_capacity_valid`

---
<h2>Actual Result</h2> 

- Test `tests/test_prepareDeploymentServiceDefinitionStep.py::test_process_application_autoscaling_scalable_target_max_capacity_invalid`  fails when it is run by itself
- Specifically, we get the following:
```
______________________ test_process_application_autoscaling_scalable_target_max_capacity_invalid _______________________
    def test_process_application_autoscaling_scalable_target_max_capacity_invalid():
        source = {}
        source['max_capacity'] = 'a'
        target = {}
        with pytest.raises(ValueError):
>           step._process_application_autoscaling_scalable_target_max_capacity(source, target)

tests/test_prepareDeploymentServiceDefinitionStep.py:324:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <ecs_crd.prepareDeploymentServiceDefinitionStep.PrepareDeploymentServiceDefinitionStep object at 0x7f13e59c91c0>
source = {'max_capacity': 'a'}, target = {}

    def _process_application_autoscaling_scalable_target_max_capacity(self, source, target):
        self._process_property(
            source = source,
            target = target,
            source_property = 'max_capacity',
            type = int,
>           default = self.infos.scale_infos.desired,
            parent_property = 'Service.AutoScaling',
            indent = 2
        )
E       AttributeError: 'NoneType' object has no attribute 'desired'

ecs_crd/prepareDeploymentServiceDefinitionStep.py:146: AttributeError
```

---

<h2>Reproduce the test failure</h2>

- Run `python3 -m pytest tests/test_prepareDeploymentServiceDefinitionStep.py::test_process_application_autoscaling_scalable_target_max_capacity_invalid` 

---
<h2>Why the Test Fails</h2> 

- The test fails because the test is dependent on some state that is not set when it is run by itself. 

---
<h2>Fix</h2>

- The changes in this pull request sets the state and makes the test pass when it is run by itself. 

---
